### PR TITLE
disable provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          provenance: false
           tags: |
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/video-conversation:dev
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/video-conversation:${{ github.sha }}


### PR DESCRIPTION
docker/build-push-action@v4はprovenanceという項目がデフォルトでtrueであるが、trueだとprovenanceという開発からビルドを経てデプロイまでの一連の過程を外部から守ってくれるオプション
しかし、うまくいっていない部分でもあり、pushするとECRではuntaggedのイメージが追加されてしまう
したがって、現状はprovenanceをfalseに設定しておくことにする

- [docker/build-push-action v3.3.0で導入されたprovenanceオプションにまつわる問題 - chroju.dev/blog](https://chroju.dev/blog/docker_buildx_slsa_provenance)
- [Github Action docker/build-push-action@v4 to ECR returns untagged images - Stack Overflow](https://stackoverflow.com/questions/75811044/github-action-docker-build-push-actionv4-to-ecr-returns-untagged-images)